### PR TITLE
Fix TokenBalance amount

### DIFF
--- a/src/views/shared/token-balance/token-balance.view.jsx
+++ b/src/views/shared/token-balance/token-balance.view.jsx
@@ -9,7 +9,7 @@ function TokenBalance ({ amount, symbol }) {
   return (
     <p className={classes.root}>
       <span className={classes.amount}>
-        {!isNaN(amount) ? amount.toFixed(2) : '--'} {symbol || <></>}
+        {!isNaN(amount) ? amount : '--'} {symbol || <></>}
       </span>
     </p>
   )


### PR DESCRIPTION
Fixes the token balance component. The value received is an string and the `toFixed` method is not available.