### PR TITLE
Hide network name is info not available

### DIFF
--- a/src/views/login/login.view.jsx
+++ b/src/views/login/login.view.jsx
@@ -106,6 +106,7 @@ function Login ({
         )}
         {
           ethereumNetworkTask.status === 'successful' &&
+          ethereumNetworkTask.data.name &&
           (currentStep !== STEP_NAME.ERROR || (currentStep === STEP_NAME.ERROR && stepData.error !== UNDER_MAINTENANCE_ERROR)) && (
             <Button
               text={capitalizeLabel(ethereumNetworkTask.data.name)}


### PR DESCRIPTION
### What does this PR does?

With Wallet connect, network info is not always available. Currently, the wallet breaks, this just hides the label.

### How to test?

Open the wallet on mobile device.

## Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Respect code style and lint
- [X] Update documentation (if needed)
