### PR TITLE
Fix rewards sidenav issues

### DIFF
--- a/src/store/global/global.thunks.js
+++ b/src/store/global/global.thunks.js
@@ -593,7 +593,13 @@ function fetchRewardAccountEligibility () {
 
     return airdropApi.getAccountEligibility(getEthereumAddress(wallet.hermezEthereumAddress))
       .then((res) => dispatch(globalActions.loadRewardAccountEligilibitySuccess(res)))
-      .catch(() => dispatch(globalActions.loadRewardAccountEligilibityFailure('An error occurred loading account eligibility.')))
+      .catch((err) => {
+        if (err.response?.status === HttpStatusCode.NOT_FOUND) {
+          dispatch(globalActions.loadRewardAccountEligilibitySuccess(false))
+        } else {
+          dispatch(globalActions.loadRewardAccountEligilibityFailure('An error occurred loading account eligibility.'))
+        }
+      })
   }
 }
 

--- a/src/views/my-account/components/rewards-card/rewards-card.view.jsx
+++ b/src/views/my-account/components/rewards-card/rewards-card.view.jsx
@@ -88,14 +88,14 @@ function RewardsCard ({
                 <p className={classes.rewardText}>
                   Today’s reward is <span className={classes.rewardPercentage}>{rewardPercentageTask.data}%</span>.&nbsp;
                   {
-                  accountEligibilityTask.data
-                    ? (
-                      <span>You earned so far {earnedRewardTask.data} HEZ ({CurrencySymbol[preferredCurrency].symbol}{getRewardAmountInPreferredCurrency(earnedRewardTask.data)}).</span>
-                      )
-                    : (
-                      <span>You earned so far 0.00 HEZ ({CurrencySymbol[preferredCurrency].symbol}0.00).</span>
-                      )
-                }
+                    accountEligibilityTask.data
+                      ? (
+                        <span>You earned so far {Number(earnedRewardTask.data).toFixed(2)} HEZ ({CurrencySymbol[preferredCurrency].symbol}{getRewardAmountInPreferredCurrency(earnedRewardTask.data)}).</span>
+                        )
+                      : (
+                        <span>You earned so far 0.00 HEZ ({CurrencySymbol[preferredCurrency].symbol}0.00).</span>
+                        )
+                  }
                 </p>
               </>
               )

--- a/src/views/my-account/components/rewards-card/rewards-card.view.jsx
+++ b/src/views/my-account/components/rewards-card/rewards-card.view.jsx
@@ -36,10 +36,6 @@ function RewardsCard ({
     rewardTask.status === 'loading' ||
     earnedRewardTask.status === 'pending' ||
     earnedRewardTask.status === 'loading' ||
-    rewardPercentageTask.status === 'pending' ||
-    rewardPercentageTask.status === 'loading' ||
-    accountEligibilityTask.status === 'pending' ||
-    accountEligibilityTask.status === 'loading' ||
     tokenTask.status === 'pending' ||
     tokenTask.status === 'loading'
   ) {

--- a/src/views/my-account/components/rewards-card/rewards-card.view.jsx
+++ b/src/views/my-account/components/rewards-card/rewards-card.view.jsx
@@ -59,7 +59,6 @@ function RewardsCard ({
           if (
             rewardTask.status === 'failed' ||
             earnedRewardTask.status === 'failed' ||
-            rewardPercentageTask.status === 'failed' ||
             accountEligibilityTask.status === 'failed' ||
             tokenTask.status === 'failed'
           ) {
@@ -86,7 +85,7 @@ function RewardsCard ({
             : (
               <>
                 <p className={classes.rewardText}>
-                  Today’s reward is <span className={classes.rewardPercentage}>{rewardPercentageTask.data}%</span>.&nbsp;
+                  Today’s reward is <span className={classes.rewardPercentage}>{rewardPercentageTask ? rewardPercentageTask.data : '--'}%</span>.&nbsp;
                   {
                     accountEligibilityTask.data
                       ? (

--- a/src/views/shared/rewards-sidenav/rewards-sidenav.view.jsx
+++ b/src/views/shared/rewards-sidenav/rewards-sidenav.view.jsx
@@ -86,10 +86,6 @@ function RewardsSidenav ({
             rewardTask.status === 'loading' ||
             earnedRewardTask.status === 'pending' ||
             earnedRewardTask.status === 'loading' ||
-            rewardPercentageTask.status === 'pending' ||
-            rewardPercentageTask.status === 'loading' ||
-            accountEligibilityTask.status === 'pending' ||
-            accountEligibilityTask.status === 'loading' ||
             tokenTask.status === 'pending' ||
             tokenTask.status === 'loading'
           ) {

--- a/src/views/shared/rewards-sidenav/rewards-sidenav.view.jsx
+++ b/src/views/shared/rewards-sidenav/rewards-sidenav.view.jsx
@@ -177,14 +177,6 @@ function RewardsSidenav ({
                     }
                   </div>
                 </div>
-
-                <div className={classes.infoTextWrapper}>
-                  <InfoGreyIcon className={classes.infoIcon} />
-                  <p className={classes.infoText}>
-                    You will receive your reward at the end of the program.
-                  </p>
-                </div>
-
                 {
                   accountEligibilityTask.data && (
                     <div className={classes.infoTextWrapper}>

--- a/src/views/shared/rewards-sidenav/rewards-sidenav.view.jsx
+++ b/src/views/shared/rewards-sidenav/rewards-sidenav.view.jsx
@@ -99,7 +99,6 @@ function RewardsSidenav ({
           if (
             rewardTask.status === 'failed' ||
             earnedRewardTask.status === 'failed' ||
-            rewardPercentageTask.status === 'failed' ||
             accountEligibilityTask.status === 'failed' ||
             tokenTask.status === 'failed'
           ) {
@@ -154,7 +153,9 @@ function RewardsSidenav ({
                 <div className={classes.rewardCard}>
                   <div className={classes.rewardGroup}>
                     <p className={classes.rewardTitle}>Today’s reward</p>
-                    <p className={`${classes.reward} ${classes.rewardPercentage}`}>{rewardPercentageTask.data}%</p>
+                    <p className={`${classes.reward} ${classes.rewardPercentage}`}>
+                      {rewardPercentageTask.data ? rewardPercentageTask.data : '--'}%
+                    </p>
                   </div>
                   <div className={classes.rewardGroup}>
                     <p className={classes.rewardTitle}>

--- a/src/views/shared/sidenav/sidenav.styles.js
+++ b/src/views/shared/sidenav/sidenav.styles.js
@@ -13,11 +13,11 @@ const useSidenavStyles = createUseStyles((theme) => ({
     justifyContent: 'flex-end',
     overflow: 'hidden',
     boxShadow: '-5px 0 30px 0 rgba(136, 139, 170, 0.15)',
-    background: theme.palette.white
+    background: theme.palette.white,
+    borderRadius: `${theme.spacing(4)}px 0 0 ${theme.spacing(4)}px`
   },
   content: {
     padding: theme.spacing(3),
-    borderRadius: `${theme.spacing(4)}px 0 0 ${theme.spacing(4)}px`,
     overflowY: 'auto'
   },
   hideButton: {


### PR DESCRIPTION
### What does this PR does?

This PR fixes some bugs related to the new rewards feature:

- Fixes the `border-radius` of the sidenav.
- Displays the earned reward with two decimals in the `rewards-card` view.
- Moves the `rewardPercentageTask` check to be able to display the UI properly when the airdrop finishes.
- Fixes the `accountEligibilityTask` thunk to dispatch a `false` when the API returns a 404.

## Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Respect code style and lint
- [x] Update documentation (if needed)
