### PR TITLE
Add reward expiration checks in real-time

### DIFF
--- a/src/views/my-account/components/rewards-card/rewards-card.view.jsx
+++ b/src/views/my-account/components/rewards-card/rewards-card.view.jsx
@@ -14,6 +14,25 @@ function RewardsCard ({
   onOpenRewardsSidenav
 }) {
   const classes = useRewardsCardStyles()
+  const [isRewardActive, setIsRewardActive] = React.useState(undefined)
+
+  React.useEffect(() => {
+    const updateTimer = () => {
+      if (rewardTask.status === 'successful') {
+        if (hasRewardExpired(rewardTask.data)) {
+          setIsRewardActive(false)
+          clearInterval(intervalId)
+        } else {
+          setIsRewardActive(true)
+        }
+      }
+    }
+    const intervalId = setInterval(updateTimer, 1000)
+
+    updateTimer()
+
+    return () => { clearInterval(intervalId) }
+  }, [rewardTask])
 
   function hasRewardExpired (reward) {
     const now = new Date().getTime()
@@ -67,7 +86,7 @@ function RewardsCard ({
             )
           }
 
-          return hasRewardExpired(rewardTask.data)
+          return isRewardActive === false
             ? (
               <>
                 <p className={classes.rewardText}>
@@ -81,7 +100,7 @@ function RewardsCard ({
             : (
               <>
                 <p className={classes.rewardText}>
-                  Today’s reward is <span className={classes.rewardPercentage}>{rewardPercentageTask ? rewardPercentageTask.data : '--'}%</span>.&nbsp;
+                  Today's reward is <span className={classes.rewardPercentage}>{rewardPercentageTask ? rewardPercentageTask.data : '--'}%</span>.&nbsp;
                   {
                     accountEligibilityTask.data
                       ? (

--- a/src/views/shared/rewards-sidenav/rewards-sidenav.view.jsx
+++ b/src/views/shared/rewards-sidenav/rewards-sidenav.view.jsx
@@ -67,14 +67,14 @@ function RewardsSidenav ({
     const updateTimer = () => {
       if (rewardTask.status === 'successful') {
         const rewardEndingTime = (rewardTask.data.initTimestamp + rewardTask.data.duration) * 1000
-        const rewardRemainingTime = rewardEndingTime - new Date().getTime()
+        const rewardTimeToEnd = rewardEndingTime - new Date().getTime()
 
         if (hasRewardExpired(rewardTask.data)) {
           setRewardRemainingTime(0)
           setIsRewardActive(false)
           clearInterval(intervalId)
         } else {
-          setRewardRemainingTime(rewardRemainingTime)
+          setRewardRemainingTime(rewardTimeToEnd)
           setIsRewardActive(true)
         }
       }


### PR DESCRIPTION
### What does this PR does?

This PR checks in realtime if the airdrop has expired or not and changes the UI accordingly. It also checks user's eligibility in realtime, so after making 2 txs and 24 Ethereum blocks he should see that he is eligible.

### How to test?

Make 2 txs after an airdrop has started and wait for the airdrop to finish.

## Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Respect code style and lint
- [x] Update documentation (if needed)
