### PR TITLE
Add mocked fiat exchange rates

### DIFF
--- a/src/apis/fiat-exchange-rates.js
+++ b/src/apis/fiat-exchange-rates.js
@@ -10,6 +10,7 @@ const baseApiUrl = FIAT_EXCHANGE_RATES_API_URL
  * @param {string[]} symbols - ISO 4217 currency codes
  * @returns {Object} - USD exchange rates for the requested symbols
  */
+// eslint-disable-next-line no-unused-vars
 function getFiatExchangeRates (symbols) {
   const params = { base: CurrencySymbol.USD.code, symbols: symbols.join(','), access_key: process.env.REACT_APP_EXCHANGE_RATES_API_KEY }
 
@@ -17,4 +18,22 @@ function getFiatExchangeRates (symbols) {
     .then(res => res.data)
 }
 
-export { getFiatExchangeRates }
+/**
+ * Mocks the USD exchange rates for the requested currency symbols
+ * @param {string[]} symbols - ISO 4217 currency codes
+ * @returns {Object} - USD exchange rates for the requested symbols
+ */
+function getMockedFiatExchangeRates () {
+  return Promise.resolve({
+    success: true,
+    base: 'USD',
+    rates: {
+      EUR: 0.837775,
+      CNY: 6.446304,
+      JPY: 110.253954,
+      GBP: 0.716945
+    }
+  })
+}
+
+export { getMockedFiatExchangeRates as getFiatExchangeRates }


### PR DESCRIPTION
<!-- 🎉 Thank you for the PR!!! 🎉 -->

Closes #532

### What does this PR does?

Adds mocked `fiatExchangeRates` to prevent getting out of API requests.

### How to test?

Run the wallet and check that no request is being made to the `api.exchangeratesapi.io` domain and the amounts are still being displayed properly.

## Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Respect code style and lint
- [x] Update documentation (if needed)
