### PR TITLE
Temporarily fix the hermezjs env when using wallet connect

### DIFF
--- a/src/store/global/global.thunks.js
+++ b/src/store/global/global.thunks.js
@@ -27,6 +27,26 @@ function setHermezEnvironment () {
     hermezjs.TxPool.initializeTransactionPool()
 
     if (!window.ethereum) {
+      if (process.env.REACT_APP_ENV === 'production') {
+        const chainId = window.location.host === 'wallet.hermez.io' ? 1 : 4
+
+        hermezjs.Environment.setEnvironment(chainId)
+      }
+
+      if (process.env.REACT_APP_ENV === 'development') {
+        hermezjs.Environment.setEnvironment({
+          baseApiUrl: process.env.REACT_APP_HERMEZ_API_URL,
+          contractAddresses: {
+            [hermezjs.Constants.ContractNames.Hermez]:
+                process.env.REACT_APP_HERMEZ_CONTRACT_ADDRESS,
+            [hermezjs.Constants.ContractNames.WithdrawalDelayer]:
+                process.env.REACT_APP_WITHDRAWAL_DELAYER_CONTRACT_ADDRESS
+          },
+          batchExplorerUrl: process.env.REACT_APP_BATCH_EXPLORER_URL,
+          etherscanUrl: process.env.REACT_APP_ETHERSCAN_URL
+        })
+      }
+
       // Dispatch an empty object as we don't know the network name at this point
       return dispatch(globalActions.loadEthereumNetworkSuccess({}))
     }


### PR DESCRIPTION
### What does this PR does?

This PR fixes the initial call to the `/state` API endpoint when MetaMask extension is not installed in the browser.

### How to test?

Try to run the wallet without MetaMask extension installed.

## Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Respect code style and lint
- [x] Update documentation (if needed)
