### PR TITLE
finding missing account index for redirect in case of transaction error

### DIFF
--- a/src/views/transaction/components/transaction-form/transaction-form.view.jsx
+++ b/src/views/transaction/components/transaction-form/transaction-form.view.jsx
@@ -231,8 +231,7 @@ function TransactionForm ({
             if (!receiverAccount && !res[1] && !isHermezBjjAddress(receiver)) {
               setDoesReceiverExist(false)
             } else {
-              // const transactionFee = getFee(fees, receiverAccount)
-              const transactionFee = 100
+              const transactionFee = getFee(fees, receiverAccount)
 
               onSubmit({
                 amount: amount,

--- a/src/views/transaction/components/transaction-form/transaction-form.view.jsx
+++ b/src/views/transaction/components/transaction-form/transaction-form.view.jsx
@@ -231,7 +231,8 @@ function TransactionForm ({
             if (!receiverAccount && !res[1] && !isHermezBjjAddress(receiver)) {
               setDoesReceiverExist(false)
             } else {
-              const transactionFee = getFee(fees, receiverAccount)
+              // const transactionFee = getFee(fees, receiverAccount)
+              const transactionFee = 100
 
               onSubmit({
                 amount: amount,

--- a/src/views/transaction/transaction.view.jsx
+++ b/src/views/transaction/transaction.view.jsx
@@ -217,9 +217,12 @@ function Transaction ({
             )
           }
           case STEP_NAME.TRANSACTION_ERROR: {
+            const stepData = steps[STEP_NAME.REVIEW_TRANSACTION]
+            const txAccountIndex = accountIndex || stepData.transaction.from.accountIndex
+
             return (
               <TransactionError
-                onFinishTransaction={() => onFinishTransaction(transactionType, accountIndex)}
+                onFinishTransaction={() => onFinishTransaction(transactionType, txAccountIndex)}
               />
             )
           }


### PR DESCRIPTION
<!-- 🎉 Thank you for the PR!!! 🎉 -->

Closes #593 

### What does this PR does?

accountIndex was missing and this was causing redirect to `/accounts/null`

### How to test?

When an error happens during a transaction and the transaction-error view appears, clicking in the button to finish the process was redirecting the user to /accounts/null, that is fixed and now leads to /accounts/:accountIndex.

## Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Respect code style and lint
- [ ] Update documentation (if needed)
