### PR TITLE
Fix tx form create account auth

### DIFF
--- a/src/views/transactions/components/transaction-form/transaction-form.view.jsx
+++ b/src/views/transactions/components/transaction-form/transaction-form.view.jsx
@@ -260,7 +260,7 @@ function TransactionForm({
         const accountChecks = [
           getAccounts(receiver, [account.token.id]),
           ...(!isHermezBjjAddress(receiver)
-            ? [getCreateAccountAuthorization(receiver).catch(() => ({}))]
+            ? [getCreateAccountAuthorization(receiver).catch(() => undefined)]
             : []),
         ];
         return Promise.all(accountChecks).then((res) => {
@@ -285,6 +285,7 @@ function TransactionForm({
       }
       default: {
         const transactionFee = getFee(fees, true);
+
         return onSubmit({
           amount: amount,
           from: {},


### PR DESCRIPTION
Closes #710.

### What does this PR does?

This PR fixes a bug when trying to send funds to another account which doesn't have the create-account-auth message signed.

### How to test?

Try to send some funds to an account which doesn't have signed the create-account-auth message.

## Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Respect code style and lint
- [x] Update documentation (if needed)
