### PR TITLE
Fix layout of l2 tx on user acceptance

### DIFF
--- a/src/views/transactions/components/transaction-overview/transaction-overview.view.tsx
+++ b/src/views/transactions/components/transaction-overview/transaction-overview.view.tsx
@@ -170,7 +170,7 @@ function TransactionOverview({
     </Container>
   );
 
-  const l1Footer = (buttonLabel: string): JSX.Element =>
+  const footer = (buttonLabel: string): JSX.Element =>
     isTransactionBeingApproved ? (
       <div className={classes.signingSpinnerWrapper}>
         <Spinner />
@@ -201,7 +201,7 @@ function TransactionOverview({
                 preferredCurrency={preferredCurrency}
                 fiatExchangeRates={fiatExchangeRates}
               />
-              {l1Footer("Deposit")}
+              {footer("Deposit")}
             </section>
           </Container>
         </div>
@@ -227,7 +227,7 @@ function TransactionOverview({
                 preferredCurrency={preferredCurrency}
                 fiatExchangeRates={fiatExchangeRates}
               />
-              {l1Footer("Force Withdrawal")}
+              {footer("Force Withdrawal")}
             </section>
           </Container>
         </div>
@@ -256,7 +256,7 @@ function TransactionOverview({
                 preferredCurrency={preferredCurrency}
                 fiatExchangeRates={fiatExchangeRates}
               />
-              {l1Footer("Withdraw")}
+              {footer("Withdraw")}
             </section>
           </Container>
         </div>

--- a/src/views/transactions/components/transaction-overview/transaction-overview.view.tsx
+++ b/src/views/transactions/components/transaction-overview/transaction-overview.view.tsx
@@ -170,18 +170,15 @@ function TransactionOverview({
     </Container>
   );
 
-  const footer = (buttonLabel: string, loaderText: string): JSX.Element =>
+  const l1Footer = (buttonLabel: string): JSX.Element =>
     isTransactionBeingApproved ? (
       <div className={classes.signingSpinnerWrapper}>
         <Spinner />
-        <p className={classes.signingText}>{loaderText}</p>
+        <p className={classes.signingText}>Sign in your connected wallet to confirm transaction</p>
       </div>
     ) : (
       <PrimaryButton label={buttonLabel} onClick={handleFormSubmit} disabled={isButtonDisabled} />
     );
-
-  const l1TxLoaderText = "Sign in your connected wallet to confirm transaction";
-  const l2TxLoaderText = "Processing transaction";
 
   switch (type) {
     case TxType.Deposit: {
@@ -204,7 +201,7 @@ function TransactionOverview({
                 preferredCurrency={preferredCurrency}
                 fiatExchangeRates={fiatExchangeRates}
               />
-              {footer("Deposit", l1TxLoaderText)}
+              {l1Footer("Deposit")}
             </section>
           </Container>
         </div>
@@ -230,7 +227,7 @@ function TransactionOverview({
                 preferredCurrency={preferredCurrency}
                 fiatExchangeRates={fiatExchangeRates}
               />
-              {footer("Force Withdrawal", l1TxLoaderText)}
+              {l1Footer("Force Withdrawal")}
             </section>
           </Container>
         </div>
@@ -259,7 +256,7 @@ function TransactionOverview({
                 preferredCurrency={preferredCurrency}
                 fiatExchangeRates={fiatExchangeRates}
               />
-              {footer("Withdraw", l1TxLoaderText)}
+              {l1Footer("Withdraw")}
             </section>
           </Container>
         </div>
@@ -293,7 +290,11 @@ function TransactionOverview({
                 preferredCurrency={preferredCurrency}
                 fiatExchangeRates={fiatExchangeRates}
               />
-              {footer("Initiate withdraw", l2TxLoaderText)}
+              <PrimaryButton
+                label="Initiate withdraw"
+                onClick={handleFormSubmit}
+                disabled={isButtonDisabled}
+              />
             </section>
           </Container>
           {isWithdrawInfoSidenavOpen && (
@@ -323,7 +324,7 @@ function TransactionOverview({
                 preferredCurrency={preferredCurrency}
                 fiatExchangeRates={fiatExchangeRates}
               />
-              {footer("Send", l2TxLoaderText)}
+              <PrimaryButton label="Send" onClick={handleFormSubmit} disabled={isButtonDisabled} />
             </section>
           </Container>
         </div>


### PR DESCRIPTION
Addresses [this comment](https://github.com/hermeznetwork/wallet-ui/pull/734#discussion_r746832109) from the previous PR.

### What does this PR does?

Fix the layout of the L2 tx to match ux and design requirements. Now on user acceptance we avoid showing a spinner with a text and instead show only the button, disabled.

## Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Respect code style and lint
- [ ] Update documentation (if needed)
