### PR TITLE
Fix a bug when retrieving the balance of an ERC-20 token

### DIFF
--- a/src/utils/ethereum.ts
+++ b/src/utils/ethereum.ts
@@ -50,7 +50,9 @@ function getTokens(
       // We can ignore if a call to the contract of a specific token fails.
       // ToDo: Find a way to properly type the functions of the contract declared through the ABI.
       // eslint-disable-next-line
-      const balance: Promise<BigNumber> = contract.balanceOf(ethereumAddress).catch(() => ({}));
+      const balance: Promise<BigNumber> = contract
+        .balanceOf(ethereumAddress)
+        .catch(() => BigNumber.from(0));
 
       return balance;
     }


### PR DESCRIPTION
### What does this PR does?

This PR fix a bug when retrieving the balance for a token in L1 which was breakin the `deposit` flow. If the user didn't have balance of an ERC-20 token, the `catch` was returning `{}` instead of a `BigNumber`, so later when trying to call the `.gt()` method it was breaking.

### How to test?

1. Load the Ethereum accounts in the first step of the `deposit` flow.

## Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Respect code style and lint
- [x] Update documentation (if needed)
