### PR TITLE
Set alpine version at dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:alpine AS base
+FROM node:lts-alpine3.12 AS base
 
 RUN apk update
 RUN apk upgrade


### PR DESCRIPTION
Define a LTS version at dockerfile for the build. It seems that tests are failing at integration-testing repo because the latest version of Alpine is having open ssl conflicts with the webpack version of this repo.