### PR TITLE
Remove not needed black color usage

### DIFF
--- a/src/views/login/components/create-account-auth/create-account-auth.styles.ts
+++ b/src/views/login/components/create-account-auth/create-account-auth.styles.ts
@@ -11,7 +11,6 @@ const useCreateAccountAuthStyles = createUseStyles((theme: Theme) => ({
   accountAuthTitle: {
     fontSize: theme.spacing(2.5),
     lineHeight: `${theme.spacing(4)}px`,
-    color: theme.palette.black.main,
     fontWeight: theme.fontWeights.bold,
     marginTop: 0,
     marginBottom: theme.spacing(2),
@@ -19,7 +18,6 @@ const useCreateAccountAuthStyles = createUseStyles((theme: Theme) => ({
   accountAuthText: {
     fontSize: theme.spacing(2),
     lineHeight: `${theme.spacing(3.5)}px`,
-    color: theme.palette.black.main,
     fontWeight: theme.fontWeights.medium,
     textAlign: "center",
     marginBottom: theme.spacing(1),

--- a/src/views/transactions/components/selected-account/selected-account.styles.ts
+++ b/src/views/transactions/components/selected-account/selected-account.styles.ts
@@ -17,7 +17,6 @@ const useSelectedAccountStyles = createUseStyles((theme: Theme) => ({
     padding: theme.spacing(2.5),
     fontSize: `${theme.spacing(2)}px`,
     fontWeight: theme.fontWeights.bold,
-    color: theme.palette.black.main,
     transition: theme.hoverTransition,
     "&:hover": {
       backgroundColor: theme.palette.primary.hover,

--- a/src/views/transactions/components/transaction-amount-input/transaction-amount-input.styles.ts
+++ b/src/views/transactions/components/transaction-amount-input/transaction-amount-input.styles.ts
@@ -27,7 +27,6 @@ const useTransactionAmountInputStyles = createUseStyles((theme: Theme) => ({
   amountCurrency: {
     fontSize: `${theme.spacing(2)}px`,
     fontWeight: theme.fontWeights.bold,
-    color: theme.palette.black.main,
     marginBottom: theme.spacing(0.5),
     [theme.breakpoints.upSm]: {
       fontSize: `${theme.spacing(2.5)}px`,

--- a/src/views/transactions/components/withdraw-info-sidenav/withdraw-info-sidenav.styles.ts
+++ b/src/views/transactions/components/withdraw-info-sidenav/withdraw-info-sidenav.styles.ts
@@ -22,7 +22,6 @@ const useWithdrawInfoSidenavStyles = createUseStyles((theme: Theme) => ({
     borderRadius: theme.spacing(2),
     padding: theme.spacing(2.5),
     marginTop: theme.spacing(2),
-    color: theme.palette.black.main,
     fontSize: theme.spacing(1.75),
     fontWeight: theme.fontWeights.medium,
   },

--- a/src/views/transactions/transfer/components/receiver-input/receiver-input.styles.ts
+++ b/src/views/transactions/transfer/components/receiver-input/receiver-input.styles.ts
@@ -22,7 +22,6 @@ const useReceiverInputStyles = createUseStyles((theme: Theme) => ({
       2.5
     )}px`,
     fontSize: `${theme.spacing(2)}px`,
-    color: theme.palette.black.main,
     fontWeight: theme.fontWeights.medium,
     outline: 0,
     border: "none",
@@ -52,7 +51,6 @@ const useReceiverInputStyles = createUseStyles((theme: Theme) => ({
     padding: theme.spacing(2),
     marginRight: theme.spacing(0.5),
     fontWeight: theme.fontWeights.bold,
-    color: theme.palette.black.main,
     [theme.breakpoints.upSm]: {
       fontSize: theme.spacing(2.5),
       marginRight: theme.spacing(3),


### PR DESCRIPTION
Closes #766.

### What does this PR does?

This PR removes all the `black` color usage across the app not needed anymore, since it's already applied to the `body`.

## Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Respect code style and lint
- [ ] Update documentation (if needed)
